### PR TITLE
Improve FallbackProvider getAnyResult() with errors

### DIFF
--- a/src.ts/providers/provider-fallback.ts
+++ b/src.ts/providers/provider-fallback.ts
@@ -305,11 +305,7 @@ function getMedian(quorum: number, results: Array<TallyResult>): undefined | big
 }
 
 function getAnyResult(quorum: number, results: Array<TallyResult>): undefined | any | Error {
-    // If any value or error meets quorum, that is our preferred result
-    const result = checkQuorum(quorum, results);
-    if (result !== undefined) { return result; }
-
-    // Otherwise, do we have any non-error result?
+    // Do we have any non-error result?
     for (const r of results) {
         if (r.value && !r.value.error) { return r.value; }
     }


### PR DESCRIPTION
Avoids doing a "checkQuorum" in getAnyResult(), because in my opinion this better matches the semantics of "getAnyResult": we shouldn't care about quorum numbers because the semantics is "any", with the exception that we give a preference to non-error results first.

I think there was something going on in checkQuorum where two error results were being combined together, and they each had weight 2 which meant that the total weight was 4 which is greater than the set quorum number 3. That's why it returned an error.